### PR TITLE
Fix HTTP 403 issue

### DIFF
--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -6,7 +6,6 @@ library(DT)
 library(dplyr)
 library(shinybusy)
 library(shinyalert)
-token <- Sys.getenv("CTUCosting_token")
 
 function(input, output, session){
 
@@ -37,10 +36,10 @@ function(input, output, session){
                  onclick = paste0("window.open('",
                                   create_rc_link(record = input$record_id,
                                  costing = input$costing,
-                                 token = token), "', '_blank')"))
+                                 token = input$token), "', '_blank')"))
     # tags$a(href = create_rc_link(record = input$record_id,
     #                              costing = input$costing,
-    #                              token = token),
+    #                              token = input$token),
     #        "Click here to go to this costing in REDCap", target = "_blank")
   })
 
@@ -93,7 +92,7 @@ function(input, output, session){
     }
   })
 
-  meta <- reactive(get_metadata(token = token))
+  meta <- reactive(get_metadata(token = input$token))
   notes <- reactive(get_notes(d()))
 
   info <- reactive({


### PR DESCRIPTION
when the global `token` was undefined (which it is outside of dev environment), it is an empty string. the global was used by mistake instead of `input$token` in two places. Their use is now replaced with `input$token` . Merry christmas Alan!