### PR TITLE
version 0.5.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CTUCosting
 Type: Package
 Title: Machinery for CTU costings
-Version: 0.5.0
+Version: 0.5.1
 Authors@R:
     c(
     person(given = "Alan G.", family = "Haynes", role = "cre",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# CTUCosting 0.5.1 (2024-05-21)
+
+* bug fix: xlsx files for SNF projects with expenses failed (8415b16).
+* Universitätsklinik für Viszerale Chirurgie und Medizin split into two units: 'Viszerale und transplantationschirurgie' and 'Gastroenterologie' with separate clinic directors.
+
 # CTUCosting 0.5.0 (2024-04-18)
 
 * Add support for costings from the DM reporting group.

--- a/R/snf_iict_yearly_budget.R
+++ b/R/snf_iict_yearly_budget.R
@@ -110,7 +110,7 @@ snf_iict_yearly_budget <- function(hours, expenses, info, debug = FALSE){
   print("SNF budget: expenses")
   # expenses total only!
   print(expenses)
-  if(!is.na(expenses)){
+  if(class(expenses) == "data.frame"){
     walk(1:ncol(expenses),
          function(column){
            value <- expenses[nrow(expenses), column]

--- a/inst/intdata/clinic_heads.csv
+++ b/inst/intdata/clinic_heads.csv
@@ -47,4 +47,6 @@
 "Universitätsklinik für Thoraxchirurgie","Prof. Dr. Ralph Alexander Schmid",TRUE
 "Universitätsklinik für Urologie","Prof. Dr. George Thalmann",TRUE
 "Universitätsklinik für Viszerale Chirurgie und Medizin","Prof. Dr. Daniel Candinas",TRUE
+"Universitätsklinik für Viszerale Chirurgie und Medizin, Viscerale und Transplantationschirurgie","Prof. Dr. Daniel Candinas",TRUE
+"Universitätsklinik für Viszerale Chirurgie und Medizin, Gastroenterologie","Prof. Dr. med. Andrew Macpherson",TRUE
 "Berner Institut für Hausarztmedizin (BIHAM)","Prof. Dr. med. Nicolas Rodondi",FALSE


### PR DESCRIPTION
* bug fix: xlsx files for SNF projects with expenses failed (8415b16).
* Universitätsklinik für Viszerale Chirurgie und Medizin split into two units: 'Viszerale und transplantationschirurgie' and 'Gastroenterologie' with separate clinic directors.