### PR TITLE
adding rounding to final hours and final costs within workpackages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CTUCosting
 Type: Package
 Title: Machinery for CTU costings
-Version: 0.7.8
+Version: 0.7.9
 Authors@R:
     c(
     person(given = "Alan G.", family = "Haynes", role = "cre",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CTUCosting 0.7.8 (2025-08-21)
+
+* adding a rounding (ceiling) of hours and costs to prevent partial amounts that mess up the formatting
+
 # CTUCosting 0.7.8 (2025-06-03)
 
 * bug fix for costings erroring without FTEs

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# CTUCosting 0.7.8 (2025-08-21)
+# CTUCosting 0.7.9 (2025-08-21)
 
 * adding a rounding (ceiling) of hours and costs to prevent partial amounts that mess up the formatting
 

--- a/R/summarize_by_.R
+++ b/R/summarize_by_.R
@@ -17,6 +17,10 @@ summarize_by_wp <- function(data){
               Hours = sum(Hours * Units),
               Rate = mean(Rate),
               Cost = sum(Cost)
+    ) |>
+    mutate(
+      Hours = ceiling(Hours),
+      Cost = ceiling(Cost)
     )
 }
 


### PR DESCRIPTION
to fix issue of partial hours running over the column width